### PR TITLE
build_one creates target subdirectory instead of silently failing

### DIFF
--- a/sassutils/builder.py
+++ b/sassutils/builder.py
@@ -168,6 +168,8 @@ class Manifest(object):
         root_path = os.path.join(package_dir, self.sass_path)
         css = compile(filename=sass_filename, include_paths=[root_path])
         css_path = os.path.join(package_dir, self.css_path, css_filename)
+        if not os.path.exists(css_path):
+            os.mkdir(os.path.dirname(css_path))
         with open(css_path, 'w') as f:
             f.write(css)
         return css_filename


### PR DESCRIPTION
Using the wsgi middleware I had to manually create subfolders in my build directory for libsass to build it - since it would find the files it had to build but couldn't open the write file to save the result.
