### PR TITLE
sass.compile should accept None as the include_paths parameter

### DIFF
--- a/sass.py
+++ b/sass.py
@@ -133,7 +133,7 @@ def compile(**kwargs):
                            ''.format(output_style, and_join(OUTPUT_STYLES)))
     fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
     try:
-        include_paths = kwargs.pop('include_paths')
+        include_paths = kwargs.pop('include_paths') or b''
     except KeyError:
         include_paths = b''
     else:


### PR DESCRIPTION
Currently, passing None as the `include_paths` parameter to sass.compile fails with the error 'include_paths must be a sequence of strings, or a colon-separated string, not None'. This causes the sassc command-line interface to fail when there are no include paths specified on the command line, because it passes None in this situation.

This patch fixes sass.compile to treat include_paths=None as equivalent to an empty list - I think this is a more 'friendly' solution, rather than changing the behaviour of sassc.
