### PR TITLE
[FIX] "UnboundLocalError: local variable 'mtime' " when with --watch

### DIFF
--- a/sassc.py
+++ b/sassc.py
@@ -114,6 +114,7 @@ def main(argv=sys.argv, stdout=sys.stdout, stderr=sys.stderr):
         pass
     while True:
         try:
+            mtime = os.stat(filename).st_mtime
             if options.source_map:
                 source_map_filename = args[1] + '.map'  # FIXME
                 css, source_map = compile(
@@ -132,7 +133,6 @@ def main(argv=sys.argv, stdout=sys.stdout, stderr=sys.stderr):
                     include_paths=options.include_paths,
                     image_path=options.image_path
                 )
-            mtime = os.stat(filename).st_mtime
         except (IOError, OSError) as e:
             error(e)
             return 3


### PR DESCRIPTION
If a file is not compilable on the 1st try, `mtime = os.stat(filename).st_mtime` would not ran, so `mtime` will not exist on `if st.st_mtime > mtime:`
