### PR TITLE
Upgrade to libsass==3.1.0.  Resolves #36.  Resolves #38.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libsass"]
 path = libsass
-url = git://github.com/dahlia/libsass-python.git
+url = git://github.com/sass/libsass.git

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,9 @@ for makefilename in [
         sources_match = MAKEFILE_SOURCES_LIST_RE.search(makefile.read())
         sources_list = sources_match.group('sources').replace('\\\n', ' ')
         libsass_sources.update(sources_list.split())
-libsass_sources = list(libsass_sources)
+libsass_sources = set(
+    x for x in libsass_sources if not x.endswith('.hpp') and not x.endswith('.h')
+)
 
 libsass_headers = [
     os.path.join(LIBSASS_DIR, 'sass_interface.h'),

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,4 @@ envlist = pypy, py26, py27, py33, py34
 deps = Werkzeug >= 0.9
 commands =
     python -c 'from shutil import *; rmtree("build", True)'
-    python setup.py test
+    python -m unittest sasstests


### PR DESCRIPTION
Things this does:
- Upgrade to libsass==3.1.0 (#38)
- Use the newer not-deprecated api
- Reimplement `compile_dirname` in python (it was dropped from the not-deprecated api)
- The reimplemented `compile_dirname` function replaces `.scss` with `.css` in the output directory (#36)

This is a prerequisite to implementing #13