### PR TITLE
Preparation for libsass3.2

### DIFF
--- a/pysass.cpp
+++ b/pysass.cpp
@@ -417,7 +417,7 @@ PySass_compile_string(PyObject *self, PyObject *args) {
     struct Sass_Context *ctx;
     struct Sass_Data_Context *context;
     struct Sass_Options *options;
-    char *string, *include_paths, *image_path;
+    char *string, *include_paths;
     const char *error_message, *output_string;
     Sass_Output_Style output_style;
     int source_comments, error_status, precision;
@@ -425,19 +425,18 @@ PySass_compile_string(PyObject *self, PyObject *args) {
     PyObject *result;
 
     if (!PyArg_ParseTuple(args,
-                          PySass_IF_PY3("yiiyyiO", "siissiO"),
+                          PySass_IF_PY3("yiiyiO", "siisiO"),
                           &string, &output_style, &source_comments,
-                          &include_paths, &image_path, &precision,
+                          &include_paths, &precision,
                           &custom_functions)) {
         return NULL;
     }
 
-    context = sass_make_data_context(string);
+    context = sass_make_data_context(strdup(string));
     options = sass_data_context_get_options(context);
     sass_option_set_output_style(options, output_style);
     sass_option_set_source_comments(options, source_comments);
     sass_option_set_include_path(options, include_paths);
-    sass_option_set_image_path(options, image_path);
     sass_option_set_precision(options, precision);
     _add_custom_functions(options, custom_functions);
 
@@ -461,16 +460,16 @@ PySass_compile_filename(PyObject *self, PyObject *args) {
     struct Sass_Context *ctx;
     struct Sass_File_Context *context;
     struct Sass_Options *options;
-    char *filename, *include_paths, *image_path;
+    char *filename, *include_paths;
     const char *error_message, *output_string, *source_map_string;
     Sass_Output_Style output_style;
     int source_comments, error_status, precision;
     PyObject *source_map_filename, *custom_functions, *result;
 
     if (!PyArg_ParseTuple(args,
-                          PySass_IF_PY3("yiiyyiOO", "siissiOO"),
+                          PySass_IF_PY3("yiiyiOO", "siisiOO"),
                           &filename, &output_style, &source_comments,
-                          &include_paths, &image_path, &precision,
+                          &include_paths, &precision,
                           &source_map_filename, &custom_functions)) {
         return NULL;
     }
@@ -493,7 +492,6 @@ PySass_compile_filename(PyObject *self, PyObject *args) {
     sass_option_set_output_style(options, output_style);
     sass_option_set_source_comments(options, source_comments);
     sass_option_set_include_path(options, include_paths);
-    sass_option_set_image_path(options, image_path);
     sass_option_set_precision(options, precision);
     _add_custom_functions(options, custom_functions);
 

--- a/sass.py
+++ b/sass.py
@@ -144,7 +144,7 @@ class SassFunction(object):
 
 def compile_dirname(
     search_path, output_path, output_style, source_comments, include_paths,
-    image_path, precision, custom_functions,
+    precision, custom_functions,
 ):
     fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
     for dirpath, _, filenames in os.walk(search_path):
@@ -159,7 +159,7 @@ def compile_dirname(
             input_filename = input_filename.encode(fs_encoding)
             s, v, _ = compile_filename(
                 input_filename, output_style, source_comments, include_paths,
-                image_path, precision, None, custom_functions,
+                precision, None, custom_functions,
             )
             if s:
                 v = v.decode('UTF-8')
@@ -192,8 +192,6 @@ def compile(**kwargs):
     :param include_paths: an optional list of paths to find ``@import``\ ed
                           SASS/CSS source files
     :type include_paths: :class:`collections.Sequence`, :class:`str`
-    :param image_path: an optional path to find images
-    :type image_path: :class:`str`
     :param precision: optional precision for numbers. :const:`5` by default.
     :type precision: :class:`int`
     :param custom_functions: optional mapping of custom functions.
@@ -229,8 +227,6 @@ def compile(**kwargs):
     :param include_paths: an optional list of paths to find ``@import``\ ed
                           SASS/CSS source files
     :type include_paths: :class:`collections.Sequence`, :class:`str`
-    :param image_path: an optional path to find images
-    :type image_path: :class:`str`
     :param precision: optional precision for numbers. :const:`5` by default.
     :type precision: :class:`int`
     :param custom_functions: optional mapping of custom functions.
@@ -269,8 +265,6 @@ def compile(**kwargs):
     :param include_paths: an optional list of paths to find ``@import``\ ed
                           SASS/CSS source files
     :type include_paths: :class:`collections.Sequence`, :class:`str`
-    :param image_path: an optional path to find images
-    :type image_path: :class:`str`
     :param precision: optional precision for numbers. :const:`5` by default.
     :type precision: :class:`int`
     :param custom_functions: optional mapping of custom functions.
@@ -424,16 +418,6 @@ def compile(**kwargs):
                             'Windows) string, not ' + repr(include_paths))
         if isinstance(include_paths, text_type):
             include_paths = include_paths.encode(fs_encoding)
-    try:
-        image_path = kwargs.pop('image_path')
-    except KeyError:
-        image_path = b'.'
-    else:
-        if not isinstance(image_path, string_types):
-            raise TypeError('image_path must be a string, not ' +
-                            repr(image_path))
-        elif isinstance(image_path, text_type):
-            image_path = image_path.encode(fs_encoding)
 
     custom_functions = kwargs.pop('custom_functions', ())
     if isinstance(custom_functions, collections.Mapping):
@@ -460,10 +444,10 @@ def compile(**kwargs):
         string = kwargs.pop('string')
         if isinstance(string, text_type):
             string = string.encode('utf-8')
-        s, v = compile_string(string,
-                              output_style, source_comments,
-                              include_paths, image_path, precision,
-                              custom_functions)
+        s, v = compile_string(
+            string, output_style, source_comments, include_paths, precision,
+            custom_functions,
+        )
         if s:
             return v.decode('utf-8')
     elif 'filename' in modes:
@@ -475,10 +459,8 @@ def compile(**kwargs):
         elif isinstance(filename, text_type):
             filename = filename.encode(fs_encoding)
         s, v, source_map = compile_filename(
-            filename,
-            output_style, source_comments,
-            include_paths, image_path, precision, source_map_filename,
-            custom_functions,
+            filename, output_style, source_comments, include_paths, precision,
+            source_map_filename, custom_functions,
         )
         if s:
             v = v.decode('utf-8')
@@ -522,10 +504,8 @@ def compile(**kwargs):
             raise ValueError('dirname must be a pair of (source_dir, '
                              'output_dir)')
         s, v = compile_dirname(
-            search_path, output_path,
-            output_style, source_comments,
-            include_paths, image_path, precision,
-            custom_functions,
+            search_path, output_path, output_style, source_comments,
+            include_paths, precision, custom_functions,
         )
         if s:
             return

--- a/sassc.py
+++ b/sassc.py
@@ -21,10 +21,6 @@ There are options as well:
    Optional directory path to find ``@import``\ ed (S)CSS files.
    Can be multiply used.
 
-.. option:: -i <dir>, --image-path <dir>
-
-   Path to find images.  Default is the current directory (:file:`./`).
-
 .. option:: -m, -g, --sourcemap
 
    Emit source map.  Requires the second argument (output CSS filename).
@@ -88,8 +84,6 @@ def main(argv=sys.argv, stdout=sys.stdout, stderr=sys.stderr):
                       dest='include_paths', action='append',
                       help='Path to find "@import"ed (S)CSS source files.  '
                            'Can be multiply used.')
-    parser.add_option('-i', '--image-path', metavar='DIR', default='./',
-                      help='Path to find images. [default: %default]')
     parser.add_option('-w', '--watch', action='store_true',
                       help='Watch file for changes.  Requires the second '
                            'argument (output css filename).')
@@ -130,7 +124,6 @@ def main(argv=sys.argv, stdout=sys.stdout, stderr=sys.stderr):
                     output_style=options.output_style,
                     source_map_filename=source_map_filename,
                     include_paths=options.include_paths,
-                    image_path=options.image_path,
                     precision=options.precision
                 )
             else:
@@ -140,7 +133,6 @@ def main(argv=sys.argv, stdout=sys.stdout, stderr=sys.stderr):
                     filename=filename,
                     output_style=options.output_style,
                     include_paths=options.include_paths,
-                    image_path=options.image_path,
                     precision=options.precision
                 )
         except (IOError, OSError) as e:


### PR DESCRIPTION
This sets the submodule to `3.2.0-beta.2`.

A few notable differences:

- Backtraces are improved
- `image_path` is gone (libsass no longer supports `image-url` function)
- `sass_make_data_context` takes ownership of the string (so we `strdup`)
- Output always ends in a `\n` now
- Improved sourcemap support
- compressed mode now outputs BOM instead of `@charset`

I think it's probably worth merging this? and then when 3.2 drops we should be able to just upgrade.