### PR TITLE
Correct variable name build_sass.description

### DIFF
--- a/sassutils/distutils.py
+++ b/sassutils/distutils.py
@@ -89,7 +89,7 @@ def validate_manifests(dist, attr, value):
 class build_sass(Command):
     """Builds SASS/SCSS files to CSS files."""
 
-    descriptin = __doc__
+    description = __doc__
     user_options = [
         (
             'output-style=', 's',


### PR DESCRIPTION
Correct typographical error in variable name build_sass.description