### PR TITLE
Added rules to discover `.sass` files when compiling directories

### DIFF
--- a/sass.py
+++ b/sass.py
@@ -150,7 +150,7 @@ def compile_dirname(
     for dirpath, _, filenames in os.walk(search_path):
         filenames = [
             filename for filename in filenames
-            if filename.endswith('.scss') or filename.endswith('.sass')
+            if (filename.endswith('.scss') or filename.endswith('.sass'))
             and not filename.startswith('_')
         ]
         for filename in filenames:

--- a/sass.py
+++ b/sass.py
@@ -150,7 +150,7 @@ def compile_dirname(
     for dirpath, _, filenames in os.walk(search_path):
         filenames = [
             filename for filename in filenames
-            if (filename.endswith('.scss') or filename.endswith('.sass'))
+            if filename.endswith(('.scss', '.sass'))
             and not filename.startswith('_')
         ]
         for filename in filenames:

--- a/sass.py
+++ b/sass.py
@@ -150,13 +150,14 @@ def compile_dirname(
     for dirpath, _, filenames in os.walk(search_path):
         filenames = [
             filename for filename in filenames
-            if filename.endswith('.scss') and not filename.startswith('_')
+            if filename.endswith('.scss') or filename.endswith('.sass')
+            and not filename.startswith('_')
         ]
         for filename in filenames:
             input_filename = os.path.join(dirpath, filename)
             relpath_to_file = os.path.relpath(input_filename, search_path)
             output_filename = os.path.join(output_path, relpath_to_file)
-            output_filename = re.sub('.scss$', '.css', output_filename)
+            output_filename = re.sub('.s[ac]ss$', '.css', output_filename)
             input_filename = input_filename.encode(fs_encoding)
             s, v, _ = compile_filename(
                 input_filename, output_style, source_comments, include_paths,


### PR DESCRIPTION
When compiling using `sass.compile(dirname=(source_dir, output_dir))`, `.sass` files where not detected. With this small commit `.sass` files are now found and everything seems to work nicely.