### PR TITLE
Write output file using UTF-8 encoding

### DIFF
--- a/sass.py
+++ b/sass.py
@@ -13,6 +13,7 @@ type.
 from __future__ import absolute_import
 import collections
 import inspect
+from io import open
 import os
 import os.path
 import re
@@ -166,7 +167,8 @@ def compile_dirname(
             if s:
                 v = v.decode('UTF-8')
                 mkdirp(os.path.dirname(output_filename))
-                with open(output_filename, 'w') as output_file:
+                with open(output_filename, 'w',
+                          encoding="UTF-8") as output_file:
                     output_file.write(v)
             else:
                 return False, v


### PR DESCRIPTION
Fixes #72, using `from io import open` for Python 2 support.