### PR TITLE
Importer callback support.

### DIFF
--- a/pysass.cpp
+++ b/pysass.cpp
@@ -442,14 +442,15 @@ Sass_Import_List _call_py_importer_f(
 ) {
     PyObject* pyfunc = (PyObject*)sass_importer_get_cookie(cb);
     PyObject* py_path = PyUnicode_FromString(path);
-    PyObject* py_args = PyTuple_New(1);
     PyObject* py_result = NULL;
+    PyObject *iterator;
+    PyObject *import_item;
     Sass_Import_List sass_imports = NULL;
     Py_ssize_t i;
-    
-    PyTuple_SetItem(py_args, 0, py_path);
-    
-    if (!(py_result = PyObject_CallObject(pyfunc, py_args))) {
+
+    py_result = PyObject_CallObject(pyfunc, PySass_IF_PY3("y", "s"), py_path);
+
+    if (!py_result) {
         sass_imports = sass_make_import_list(1);
         sass_imports[0] = sass_make_import_entry(path, 0, 0);
         

--- a/pysass.cpp
+++ b/pysass.cpp
@@ -462,8 +462,9 @@ Sass_Import_List _call_py_importer_f(
                              &path_str, &source_str, &sourcemap_str);
         }
         
-        /* POSSIBLE LEAK: owns arg source_str, sourcemap_str, but NOT path_str, ownership given @XXX?,
-           ref: https://github.com/sass/libsass/blob/master/docs/api-importer.md#return-imports */
+        if ( source_str ) source_str = strdup(source_str);
+        if ( sourcemap_str ) sourcemap_str = strdup(sourcemap_str);
+        
         sass_imports[i] = sass_make_import_entry(path_str, source_str, sourcemap_str)
         
         Py_XDECREF(import_item);

--- a/pysass.cpp
+++ b/pysass.cpp
@@ -462,14 +462,11 @@ Sass_Import_List _call_py_importer_f(
                               0, 0);
 
         Py_XDECREF(exc);
-        Py_XDECREF(py_args);
         Py_XDECREF(py_result);
         return sass_imports;
     }
-    
-    Py_XDECREF(py_args);
-        
-    if ( py_result == Py_None ) {
+
+    if (py_result == Py_None) {
         Py_XDECREF(py_result);
         return 0;
     }
@@ -481,22 +478,15 @@ Sass_Import_List _call_py_importer_f(
         char* path_str = NULL;  /* XXX: Memory leak? */
         char* source_str = NULL;
         char* sourcemap_str = NULL;
-        
-        /* GET_ITEM doesn't auto-retain. Future armoring relating to above
-           TODO, where iteration may return to the Python code context. */
-        Py_INCREF(import_item);
-        
+
         /* TODO: Switch statement and error handling for default case. Better way? */
         if ( PyTuple_GET_SIZE(import_item) == 1 ) {
-            fprintf(stderr, "il cb item 1-tup\n");
             PyArg_ParseTuple(import_item, "es",
                              0, &path_str);
         } else if ( PyTuple_GET_SIZE(import_item) == 2 ) {
-            fprintf(stderr, "il cb item 2-tup\n");
             PyArg_ParseTuple(import_item, "eses",
                              0, &path_str, 0, &source_str);
         } else if ( PyTuple_GET_SIZE(import_item) == 3 ) {
-            fprintf(stderr, "il cb item 3-tup\n");
             PyArg_ParseTuple(import_item, "eseses",
                              0, &path_str, 0, &source_str, 0, &sourcemap_str);
         }

--- a/pysass.cpp
+++ b/pysass.cpp
@@ -475,10 +475,9 @@ Sass_Import_List _call_py_importer_f(
     }
 
     sass_imports = sass_make_import_list(PyList_Size(py_result));
-    
-    /* TODO: Iterator instead of literal list? Memory savings Python-side! */
-    for (i = 0; i < PyList_GET_SIZE(py_result); i += 1) {
-        PyObject* import_item = PyList_GET_ITEM(py_result, i);
+
+    iterator = PyObject_GetIter(obj);
+    while (import_item = PyIter_Next(iterator)) {
         char* path_str = NULL;  /* XXX: Memory leak? */
         char* source_str = NULL;
         char* sourcemap_str = NULL;
@@ -513,6 +512,7 @@ Sass_Import_List _call_py_importer_f(
         Py_XDECREF(import_item);
     }
 
+    Py_XDECREF(iterator);
     Py_XDECREF(py_result);
 
     return sass_imports;

--- a/pysass.cpp
+++ b/pysass.cpp
@@ -453,14 +453,14 @@ Sass_Import_List _call_py_importer_f(
     if (!py_result) {
         sass_imports = sass_make_import_list(1);
         sass_imports[0] = sass_make_import_entry(path, 0, 0);
-        
+
         PyObject* exc = _exception_to_bytes();
         char* err = PySass_Bytes_AS_STRING(exc);
-        
+
         sass_import_set_error(sass_imports[0],
                               err,
                               0, 0);
-        
+
         Py_XDECREF(exc);
         Py_XDECREF(py_args);
         Py_XDECREF(py_result);
@@ -473,7 +473,7 @@ Sass_Import_List _call_py_importer_f(
         Py_XDECREF(py_result);
         return 0;
     }
-    
+
     sass_imports = sass_make_import_list(PyList_Size(py_result));
     
     /* TODO: Iterator instead of literal list? Memory savings Python-side! */
@@ -501,20 +501,20 @@ Sass_Import_List _call_py_importer_f(
             PyArg_ParseTuple(import_item, "eseses",
                              0, &path_str, 0, &source_str, 0, &sourcemap_str);
         }
-        
+
         /* We need to give copies of these arguments; libsass handles
            deallocation of them later, whereas path_str is left flapping
            in the breeze -- it's treated const, so that's okay. */
         if ( source_str ) source_str = strdup(source_str);
         if ( sourcemap_str ) sourcemap_str = strdup(sourcemap_str);
-        
+
         sass_imports[i] = sass_make_import_entry(path_str, source_str, sourcemap_str);
-        
+
         Py_XDECREF(import_item);
     }
-    
+
     Py_XDECREF(py_result);
-    
+
     return sass_imports;
 }
 

--- a/pysass.cpp
+++ b/pysass.cpp
@@ -570,9 +570,8 @@ PySass_compile_filename(PyObject *self, PyObject *args) {
     PyObject *source_map_filename, *custom_functions, *custom_importers,
              *result;
     
-
     if (!PyArg_ParseTuple(args,
-                          PySass_IF_PY3("yiiyiOOiO", "siisiOOiO"),
+                          PySass_IF_PY3("yiiyiOOO", "siisiOOO"),
                           &filename, &output_style, &source_comments,
                           &include_paths, &precision,
                           &source_map_filename, &custom_functions,

--- a/pysass.cpp
+++ b/pysass.cpp
@@ -473,7 +473,7 @@ Sass_Import_List _call_py_importer_f(
 
     sass_imports = sass_make_import_list(PyList_Size(py_result));
 
-    iterator = PyObject_GetIter(obj);
+    iterator = PyObject_GetIter(py_result);
     while (import_item = PyIter_Next(iterator)) {
         char* path_str = NULL;  /* XXX: Memory leak? */
         char* source_str = NULL;

--- a/pysass.cpp
+++ b/pysass.cpp
@@ -424,6 +424,7 @@ Sass_Import_List _call_py_importer_f(
         
         sass_import_set_error(list[0], strdup(message), 0, 0);
         
+        Py_XDECREF(py_args);
         Py_XDECREF(py_result);
         return sass_imports;
     }
@@ -443,6 +444,8 @@ Sass_Import_List _call_py_importer_f(
         char* path_str = NULL;  /* XXX: Memory leak? */
         char* source_str = NULL;
         char* sourcemap_str = NULL;
+        
+        Py_INCREF(import_item);  /* GET_ITEM doesn't auto-retain. */
         
         /* TODO: Switch statement and error handling for default case. Better way? */
         if ( PyTuple_GET_SIZE() == 1 ) {

--- a/pysass.cpp
+++ b/pysass.cpp
@@ -487,6 +487,10 @@ static void _add_custom_importers(
 ) {
     Py_ssize_t i;
     Sass_Importer_List importer_list;
+    
+    if ( custom_importers == Py_None ) {
+        return;
+    }
    
     importer_list = sass_make_importer_list(PyList_Size(custom_importers));
     

--- a/pysass.cpp
+++ b/pysass.cpp
@@ -488,17 +488,17 @@ Sass_Import_List _call_py_importer_f(
         
         /* TODO: Switch statement and error handling for default case. Better way? */
         if ( PyTuple_GET_SIZE(import_item) == 1 ) {
-            PyArg_ParseTuple(import_item,
-                             PySass_IF_PY3("y", "s"),
-                             &path_str);
+            fprintf(stderr, "il cb item 1-tup\n");
+            PyArg_ParseTuple(import_item, "es",
+                             0, &path_str);
         } else if ( PyTuple_GET_SIZE(import_item) == 2 ) {
-            PyArg_ParseTuple(import_item,
-                             PySass_IF_PY3("yy", "ss"),
-                             &path_str, &source_str);
+            fprintf(stderr, "il cb item 2-tup\n");
+            PyArg_ParseTuple(import_item, "eses",
+                             0, &path_str, 0, &source_str);
         } else if ( PyTuple_GET_SIZE(import_item) == 3 ) {
-            PyArg_ParseTuple(import_item,
-                             PySass_IF_PY3("yyy", "sss"),
-                             &path_str, &source_str, &sourcemap_str);
+            fprintf(stderr, "il cb item 3-tup\n");
+            PyArg_ParseTuple(import_item, "eseses",
+                             0, &path_str, 0, &source_str, 0, &sourcemap_str);
         }
         
         /* We need to give copies of these arguments; libsass handles
@@ -534,8 +534,7 @@ static void _add_custom_importers(
         int priority = 0;
         PyObject* import_function = NULL;
         
-        PyArg_ParseTuple(item,
-                         PySass_IF_PY3("iO", "iO"),
+        PyArg_ParseTuple(item, "iO",
                          &priority, &import_function);
         
         importer_list[i] = sass_make_importer(_call_py_importer_f,

--- a/sass.py
+++ b/sass.py
@@ -344,46 +344,46 @@ def compile(**kwargs):
               ...,
               custom_functions={func_name}
           )
-    
+
     .. _importer-callbacks:
 
     Newer versions of ``libsass`` allow developers to define callbacks to be
     called and given a chance to process ``@import`` directives. You can
     define yours by passing in a list of callables via the ``importers``
     parameter. The callables must be passed as 2-tuples in the form:
-    
+
     .. code-block:: python
-    
+
         (priority_int, callback_fn)
-    
+
     A priority of zero is acceptable; priority determines the order callbacks
     are attempted.
-    
+
     These callbacks must accept a single string argument representing the path
     passed to the ``@import`` directive, and either return ``None`` to
     indicate the path wasn't handled by that callback (to continue with others
     or fall back on internal ``libsass`` filesystem behaviour) or a list of
     one or more tuples, each in one of three forms:
-    
+
     * A 1-tuple representing an alternate path to handle internally; or,
     * A 2-tuple representing an alternate path and the content that path
       represents; or,
     * A 3-tuple representing the same as the 2-tuple with the addition of a
       "sourcemap".
-    
+
     All tuple return values must be strings. As a not overly realistic
     example:
-    
+
     .. code-block:: python
-    
+
         def my_importer(path):
             return [(path, '#' + path + ' { color: red; }')]
-        
+
         sass.compile(
                 ...,
                 importers=[(0, my_importer)]
             )
-    
+
     Now, within the style source, attempting to ``@import 'button';`` will
     instead attach ``color: red`` as a property of an element with the
     imported name.
@@ -498,7 +498,7 @@ def compile(**kwargs):
             '- a set/sequence of named functions,\n'
             'not {1!r}'.format(SassFunction, custom_functions)
         )
-    
+
     importers = kwargs.pop('importers', None)
 
     if 'string' in modes:

--- a/sass.py
+++ b/sass.py
@@ -209,6 +209,10 @@ def compile(**kwargs):
                      formatted. :const:`False` by default
     :type indented: :class:`bool`
     :returns: the compiled CSS string
+    :param importer: optional callback function.
+                     see also below `importer callbacks
+                     <importer-callbacks>`_ description
+    :type importer: :class:`collections.Callable`
     :rtype: :class:`str`
     :raises sass.CompileError: when it fails for any reason
                                (for example the given SASS has broken syntax)
@@ -336,6 +340,25 @@ def compile(**kwargs):
               ...,
               custom_functions={func_name}
           )
+    
+    .. _importer-callbacks:
+
+    Newer versions of ``libsass`` allow developers to define a callback to be
+    called to be given a chance to process ``@import`` directives. You can
+    define yours by passing in a callable via the ``importer`` parameter.
+    
+    This callback must accept a single string argument representing the path
+    passed to the ``@import`` directive, and either return ``None`` to
+    indicate the path should be handled internally by ``libsass``, or a list
+    of one or more tuples, each in one of three forms:
+    
+    * A 1-tuple representing an alternate path to handle internally; or,
+    * A 2-tuple representing an alternate path and the content that path
+      represents; or,
+    * A 3-tuple representing the same as the 2-tuple with the addition of a
+      "sourcemap".
+    
+    All tuple values must be strings.
 
     .. versionadded:: 0.4.0
        Added ``source_comments`` and ``source_map_filename`` parameters.

--- a/sass.py
+++ b/sass.py
@@ -146,7 +146,7 @@ class SassFunction(object):
 
 def compile_dirname(
     search_path, output_path, output_style, source_comments, include_paths,
-    precision, custom_functions,
+    precision, custom_functions, importers
 ):
     fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
     for dirpath, _, filenames in os.walk(search_path):
@@ -163,7 +163,7 @@ def compile_dirname(
             input_filename = input_filename.encode(fs_encoding)
             s, v, _ = compile_filename(
                 input_filename, output_style, source_comments, include_paths,
-                precision, None, custom_functions,
+                precision, None, custom_functions, importers
             )
             if s:
                 v = v.decode('UTF-8')
@@ -498,6 +498,8 @@ def compile(**kwargs):
             '- a set/sequence of named functions,\n'
             'not {1!r}'.format(SassFunction, custom_functions)
         )
+    
+    importers = kwargs.pop('importers', None)
 
     if 'string' in modes:
         string = kwargs.pop('string')
@@ -509,7 +511,7 @@ def compile(**kwargs):
                             repr(source_comments))
         s, v = compile_string(
             string, output_style, source_comments, include_paths, precision,
-            custom_functions, indented
+            custom_functions, indented, importers
         )
         if s:
             return v.decode('utf-8')
@@ -523,7 +525,7 @@ def compile(**kwargs):
             filename = filename.encode(fs_encoding)
         s, v, source_map = compile_filename(
             filename, output_style, source_comments, include_paths, precision,
-            source_map_filename, custom_functions,
+            source_map_filename, custom_functions, importers
         )
         if s:
             v = v.decode('utf-8')
@@ -568,7 +570,7 @@ def compile(**kwargs):
                              'output_dir)')
         s, v = compile_dirname(
             search_path, output_path, output_style, source_comments,
-            include_paths, precision, custom_functions,
+            include_paths, precision, custom_functions, importers
         )
         if s:
             return

--- a/sasstests.py
+++ b/sasstests.py
@@ -260,7 +260,7 @@ a {
         actual = sass.compile(string='a\n\tb\n\t\tcolor: blue;',
                               indented=True)
         assert actual == 'a b {\n  color: blue; }\n'
-    
+
     # TODO: Test "nop" (return None) handling. Pseudo-code.
     def test_compile_string_with_importer_callback(self):
         def importer_callback(path):
@@ -268,10 +268,10 @@ a {
                 (path, '#' + path + ' { color: blue; }\n'),
                 (path, '.' + path + ' { color: red; }\n')
             ]
-        
+
         source = '''@import 'button';
         a { color: green; }'''
-        
+
         actual = sass.compile(string=source,
                               importers=[(0, importer_callback)])
         assert actual == """#button {

--- a/sasstests.py
+++ b/sasstests.py
@@ -264,7 +264,6 @@ a {
     # TODO: Test "nop" (return None) handling. Pseudo-code.
     def test_compile_string_with_importer_callback(self):
         def importer_callback(path):
-            print("HERE")
             return [
                 (path, '#' + path + ' { color: blue; }\n'),
                 (path, '.' + path + ' { color: red; }\n')
@@ -275,10 +274,16 @@ a {
         
         actual = sass.compile(string=source,
                               importers=[(0, importer_callback)])
-        assert actual == "#button { color: blue; }\n" \
-                         ".button { color: red; }\n" \
-                         "a { color: green; }", "got: " + actual
-    
+        assert actual == """#button {
+  color: blue; }
+
+#button {
+  color: blue; }
+
+a {
+  color: green; }
+"""
+
     def test_compile_string_deprecated_source_comments_line_numbers(self):
         source = '''a {
             b { color: blue; }

--- a/sasstests.py
+++ b/sasstests.py
@@ -260,7 +260,23 @@ a {
         actual = sass.compile(string='a\n\tb\n\t\tcolor: blue;',
                               indented=True)
         assert actual == 'a b {\n  color: blue; }\n'
-
+    
+    # TODO: Test "nop" (return None) handling. Pseudo-code.
+    def test_compile_string_with_importer_callback(self):
+        def importer_callback(path):
+            return [
+                (path, '#' + path + ' { color: blue; }')
+                (path, '.' + path + ' { color: red; }')
+            ]
+        
+        source = '''@import('button')
+        a { color: green; }'''
+        
+        actual = sass.compile(string=source, importer=importer_callback)
+        assert actual == "#button { color: blue; }\n"
+                         ".button { color: red; }\n"
+                         "a { color: green; }"
+    
     def test_compile_string_deprecated_source_comments_line_numbers(self):
         source = '''a {
             b { color: blue; }

--- a/sasstests.py
+++ b/sasstests.py
@@ -264,18 +264,20 @@ a {
     # TODO: Test "nop" (return None) handling. Pseudo-code.
     def test_compile_string_with_importer_callback(self):
         def importer_callback(path):
+            print("HERE")
             return [
-                (path, '#' + path + ' { color: blue; }')
-                (path, '.' + path + ' { color: red; }')
+                (path, '#' + path + ' { color: blue; }\n'),
+                (path, '.' + path + ' { color: red; }\n')
             ]
         
-        source = '''@import('button')
+        source = '''@import 'button';
         a { color: green; }'''
         
-        actual = sass.compile(string=source, importer=importer_callback)
-        assert actual == "#button { color: blue; }\n"
-                         ".button { color: red; }\n"
-                         "a { color: green; }"
+        actual = sass.compile(string=source,
+                              importers=[(0, importer_callback)])
+        assert actual == "#button { color: blue; }\n" \
+                         ".button { color: red; }\n" \
+                         "a { color: green; }", "got: " + actual
     
     def test_compile_string_deprecated_source_comments_line_numbers(self):
         source = '''a {


### PR DESCRIPTION
Wanted to submit this for some initial review; this is the first chunk of CAPI extension I’ve touched.  It’s not complete by far, the test will likely explode and eat someone’s cat, etc.  There are some comments in the code so far, including a possible memory leak. Other to-dos include:

* Documenting what version of `libsass` is required.
* Mentioning the version of this package the argument is added.
* Actually wiring it in.

Work on #81.