### PR TITLE
Stop forcing debugging comments when creating sourcemap

### DIFF
--- a/pysass.cpp
+++ b/pysass.cpp
@@ -575,7 +575,7 @@ PySass_compile_filename(PyObject *self, PyObject *args) {
     context = sass_make_file_context(filename);
     options = sass_file_context_get_options(context);
 
-    if (source_comments && PySass_Bytes_Check(source_map_filename)) {
+    if (PySass_Bytes_Check(source_map_filename)) {
         size_t source_map_file_len = PySass_Bytes_GET_SIZE(source_map_filename);
         if (source_map_file_len) {
             char *source_map_file = (char *) malloc(source_map_file_len + 1);

--- a/sass.py
+++ b/sass.py
@@ -537,8 +537,6 @@ def compile(**kwargs):
         raise CompileError('source_map_filename is only available with '
                            'filename= keyword argument since it has to be '
                            'aware of it')
-    if source_map_filename is not None:
-        source_comments = True
     try:
         include_paths = kwargs.pop('include_paths') or b''
     except KeyError:

--- a/sasstests.py
+++ b/sasstests.py
@@ -45,10 +45,8 @@ body {
 '''
 
 A_EXPECTED_CSS_WITH_MAP = '''\
-/* line 6, SOURCE */
 body {
   background-color: green; }
-  /* line 8, SOURCE */
   body a {
     color: blue; }
 
@@ -60,8 +58,8 @@ A_EXPECTED_MAP = {
     'sources': ['test/a.scss'],
     'names': [],
     'mappings': (
-        ';AAKA,AAAA,IAAI,CAAC;EAHH,gBAAgB,EAAE,KAAM,GAQzB;;EALD,AAEE,IAFE,'
-        'CAEF,CAAC,CAAC;IACA,KAAK,EAAE,IAAK,GACb'
+        'AAKA,AAAA,IAAI,CAAC;EAHH,gBAAgB,EAAE,KAAM,GAQzB;EALD,AAEE,'
+        'IAFE,CAEF,CAAC,CAAC;IACA,KAAK,EAAE,IAAK,GACb'
     ),
 }
 
@@ -71,7 +69,6 @@ b i {
 '''
 
 B_EXPECTED_CSS_WITH_MAP = '''\
-/* line 2, SOURCE */
 b i {
   font-size: 20px; }
 
@@ -97,10 +94,8 @@ body {
 
 D_EXPECTED_CSS_WITH_MAP = '''\
 @charset "UTF-8";
-/* line 6, SOURCE */
 body {
   background-color: green; }
-  /* line 8, SOURCE */
   body a {
     font: '나눔고딕', sans-serif; }
 
@@ -446,10 +441,7 @@ a {
             source_map_filename='a.scss.css.map'
         )
         self.assertEqual(
-            A_EXPECTED_CSS_WITH_MAP.replace(
-                'SOURCE',
-                normalize_path(os.path.abspath(filename))
-            ),
+            A_EXPECTED_CSS_WITH_MAP,
             actual
         )
         self.assert_source_map_equal(A_EXPECTED_MAP, source_map)
@@ -612,7 +604,7 @@ class ManifestTestCase(BaseTestCase):
                     'sources': ['../test/b.scss'],
                     'names': [],
                     'mappings': (
-                        ';AAAA,AACE,CADD,CACC,CAAC,CAAC;EACA,SAAS,EAAE,IAAK,'
+                        'AAAA,AACE,CADD,CACC,CAAC,CAAC;EACA,SAAS,EAAE,IAAK,'
                         'GACjB'
                     ),
                 },
@@ -632,7 +624,7 @@ class ManifestTestCase(BaseTestCase):
                     'sources': ['../test/d.scss'],
                     'names': [],
                     'mappings': (
-                        ';;AAKA,AAAA,IAAI,CAAC;EAHH,gBAAgB,EAAE,KAAM,GAQzB;;'
+                        ';AAKA,AAAA,IAAI,CAAC;EAHH,gBAAgB,EAAE,KAAM,GAQzB;'
                         'EALD,AAEE,IAFE,CAEF,CAAC,CAAC;IACA,IAAI,EAAE,0BAA2B,'
                         'GAClC'
                     ),
@@ -667,7 +659,7 @@ class WsgiTestCase(BaseTestCase):
             self.assertEqual(200, r.status_code)
             src_path = normalize_path(os.path.join(src_dir, 'a.scss'))
             self.assert_bytes_equal(
-                b(A_EXPECTED_CSS_WITH_MAP.replace('SOURCE', src_path)),
+                b(A_EXPECTED_CSS_WITH_MAP),
                 r.data
             )
             self.assertEqual('text/css', r.mimetype)
@@ -818,9 +810,7 @@ class SasscTestCase(BaseTestCase):
             self.assertEqual('', self.out.getvalue())
             with open(out_filename) as f:
                 self.assertEqual(
-                    A_EXPECTED_CSS_WITH_MAP.replace(
-                        'SOURCE', normalize_path(src_filename)
-                    ),
+                    A_EXPECTED_CSS_WITH_MAP,
                     f.read().strip()
                 )
             with open(out_filename + '.map') as f:

--- a/sasstests.py
+++ b/sasstests.py
@@ -657,7 +657,6 @@ class WsgiTestCase(BaseTestCase):
             self.assertEqual('text/plain', r.mimetype)
             r = client.get('/static/a.scss.css')
             self.assertEqual(200, r.status_code)
-            src_path = normalize_path(os.path.join(src_dir, 'a.scss'))
             self.assert_bytes_equal(
                 b(A_EXPECTED_CSS_WITH_MAP),
                 r.data


### PR DESCRIPTION
fix for #124.  Essentially removing the code that forces debug comments to be on when someone requests a sourcemap.