### PR TITLE
Remove now default 'sudo: false'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
 - pypy


### PR DESCRIPTION
'sudo: false' is now default on Travis CI.