### PR TITLE
Add a script to build manylinux wheels

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ omit =
     /usr/*
     */tmp*
     */setup.py
+    */build_manylinux_wheels.py
     */upload_appveyor_builds.py
 
 [report]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,6 +56,8 @@ Here's a brief check list for releasing a new version:
   takes longer than an hour.  These wheels are not automatically uploaded,
   but there's upload_appveyor_builds.py script that downloads built wheels and
   uploads them to PyPI.
+- Run build_manylinux_wheels.py to build linux wheels and upload them to
+  PyPI (takes ~10 minutes).
 - The `docs website`__ also has to be updated.
   It's currently a static website deployed on GitHub Pages.
   Use ``python setup.py upload_doc`` command.

--- a/build_manylinux_wheels.py
+++ b/build_manylinux_wheels.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3.5
+"""Script for building 'manylinux' wheels for libsass.
+
+Run me after putting the source distribution on pypi.
+
+See: https://www.python.org/dev/peps/pep-0513/
+"""
+import os
+import pipes
+import subprocess
+import tempfile
+
+from twine.commands import upload
+
+
+def check_call(*cmd):
+    print(
+        'build-manylinux-wheels>> ' +
+        ' '.join(pipes.quote(part) for part in cmd),
+    )
+    subprocess.check_call(cmd)
+
+
+def main():
+    os.makedirs('dist', exist_ok=True)
+    for python in (
+            'cp26-cp26mu',
+            'cp27-cp27mu',
+            'cp34-cp34m',
+            'cp35-cp35m',
+    ):
+        with tempfile.TemporaryDirectory() as work:
+            pip = '/opt/python/{}/bin/pip'.format(python)
+            check_call(
+                'docker', 'run', '-ti',
+                # Use this so the files are not owned by root
+                '--user', '{}:{}'.format(os.getuid(), os.getgid()),
+                # We'll do building in /work and copy results to /dist
+                '-v', '{}:/work:rw'.format(work),
+                '-v', '{}:/dist:rw'.format(os.path.abspath('dist')),
+                'quay.io/pypa/manylinux1_x86_64:latest',
+                'bash', '-exc',
+                '{} wheel --verbose --wheel-dir /work --no-deps libsass && '
+                'auditwheel repair --wheel-dir /dist /work/*.whl'.format(pip)
+            )
+    dists = tuple(os.path.join('dist', p) for p in os.listdir('dist'))
+    return upload.main(('-r', 'pypi') + dists)
+
+if __name__ == '__main__':
+    exit(main())


### PR DESCRIPTION
Resolves #75
Resolves #150

CC @samuelcolvin

For more on the "manylinux" spec, see the pep: https://www.python.org/dev/peps/pep-0513/

(Personal notes):
- I really don't like the manylinux spec for the way it bundles `.so` files into the wheel (which has security implications) -- but in our case it doesn't actually bundle any of the shared objects as these are the only things linked (yay?):
```
	linux-vdso.so.1 =>  (0x00007ffcab9aa000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fbfb695c000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fbfb6653000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fbfb643c000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fbfb621f000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fbfb5e56000)
	/lib64/ld-linux-x86-64.so.2 (0x00005609e2a1a000)
```