### PR TITLE
Upgrade libsass to 3.3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,20 +81,7 @@ if sys.platform == 'win32':
     if get_build_version() < 14.0:
         msvc9compiler.get_build_version = lambda: 14.0
         msvc9compiler.VERSION = 14.0
-    # Workaround http://bugs.python.org/issue4431 under Python <= 2.6
-    if sys.version_info < (2, 7):
-        def spawn(self, cmd):
-            from distutils.spawn import spawn
-            if cmd[0] == self.linker:
-                for i, val in enumerate(cmd):
-                    if val.startswith('/MANIFESTFILE:'):
-                        spawn(cmd[:i] + ['/MANIFEST'] + cmd[i:],
-                              dry_run=self.dry_run)
-                        return
-            spawn(cmd, dry_run=self.dry_run)
-        from distutils.msvc9compiler import MSVCCompiler
-        MSVCCompiler.spawn = spawn
-    flags = ['-c', '-O2', '/EHsc', '/MT']
+    flags = ['/Od', '/EHsc', '/MT']
     link_flags = []
 else:
     flags = [


### PR DESCRIPTION
- Disable debug symbols under msvc to avoid buggy /DEBUG mode
- Remove python2.6 msvc monkeypatch
- Update libsass submodule to 3.3.6

This may fix the problem that prevented us from bumping to 3.3.6, this patch includes that bump