### PR TITLE
Fix warnings when building sphinx docs.  Resolves #179

### DIFF
--- a/sassutils/wsgi.py
+++ b/sassutils/wsgi.py
@@ -18,7 +18,7 @@ __all__ = 'SassMiddleware',
 
 
 class SassMiddleware(object):
-    """WSGI middleware for development purpose.  Everytime a CSS file has
+    r"""WSGI middleware for development purpose.  Everytime a CSS file has
     requested it finds a matched SASS/SCSS source file and then compiled
     it into CSS.
 
@@ -30,23 +30,21 @@ class SassMiddleware(object):
 
         .. code-block:: css
 
-           /*
-           Error: invalid property name
-           */
+            /*
+            Error: invalid property name
+            */
 
     Red text in ``body:before``
         The result CSS draws detailed error message in ``:before``
-        pseudo-class of ``body`` element e.g.::
+        pseudo-class of ``body`` element e.g.:
 
         .. code-block:: css
 
-           /*
-           body:before {
-             content: 'Error: invalid property name';
-             color: maroon;
-             background-color: white;
-           }
-           */
+            body:before {
+                content: 'Error: invalid property name';
+                color: maroon;
+                background-color: white;
+            }
 
         In most cases you could be aware of syntax error by refreshing your
         working document because it will removes all other styles and leaves


### PR DESCRIPTION
This took me longer than I care to admit to figure out :)

the warnings were point at unrelated lines.  In order to figure out the actual lines you need to write the docstring to a file and run `rst2html.py` against that file (and then ignore the sphinx-specific directive error messages).

The raw string is to fix 2 `\n`s in a code block.  I removed the comments around the css just for readability.  The actual fix was removing an extraneous `:` a few lines up.