### PR TITLE
Ignore pytests's cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .*.swp
 .DS_Store
 ._.DS_Store
+.cache/
 .coverage
 .tox
 /.libsass-upstream-version


### PR DESCRIPTION
Git keeps bugging me about a .cache folder.