### PR TITLE
Remove pypy3 from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy, pypy3, py27, py34, py35, py36
+envlist = pypy, py27, py34, py35, py36
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Since setuptools has dropped support, it's difficult for us to test against this.  Our library is known to work, but we cannot test it in CI