### PR TITLE
Temporarily revert the 3.5 releases

### DIFF
--- a/pysass.cpp
+++ b/pysass.cpp
@@ -68,8 +68,6 @@ static PyObject* _to_py_value(const union Sass_Value* value) {
             size_t i = 0;
             PyObject* items = PyTuple_New(sass_list_get_length(value));
             PyObject* separator = sass_comma;
-            int is_bracketed = sass_list_get_is_bracketed(value);
-            PyObject* bracketed = PyBool_FromLong(is_bracketed);
             switch (sass_list_get_separator(value)) {
                 case SASS_COMMA:
                     separator = sass_comma;
@@ -89,7 +87,7 @@ static PyObject* _to_py_value(const union Sass_Value* value) {
                 );
             }
             retv = PyObject_CallMethod(
-                types_mod, "SassList", "OOO", items, separator, bracketed
+                types_mod, "SassList", "OO", items, separator
             );
             break;
         }
@@ -153,7 +151,6 @@ static union Sass_Value* _list_to_sass_value(PyObject* value) {
     Py_ssize_t i = 0;
     PyObject* items = PyObject_GetAttrString(value, "items");
     PyObject* separator = PyObject_GetAttrString(value, "separator");
-    PyObject* bracketed = PyObject_GetAttrString(value, "bracketed");
     Sass_Separator sep = SASS_COMMA;
     if (separator == sass_comma) {
         sep = SASS_COMMA;
@@ -162,8 +159,7 @@ static union Sass_Value* _list_to_sass_value(PyObject* value) {
     } else {
         assert(0);
     }
-    int is_bracketed = bracketed == Py_True;
-    retv = sass_make_list(PyTuple_Size(items), sep, is_bracketed);
+    retv = sass_make_list(PyTuple_Size(items), sep);
     for (i = 0; i < PyTuple_Size(items); i += 1) {
         sass_list_set_value(
             retv, i, _to_sass_value(PyTuple_GET_ITEM(items, i))
@@ -174,7 +170,6 @@ static union Sass_Value* _list_to_sass_value(PyObject* value) {
     Py_DECREF(sass_space);
     Py_DECREF(items);
     Py_DECREF(separator);
-    Py_DECREF(bracketed);
     return retv;
 }
 

--- a/sass.py
+++ b/sass.py
@@ -705,15 +705,12 @@ SASS_SEPARATOR_SPACE = collections.namedtuple('SASS_SEPARATOR_SPACE', ())()
 SEPARATORS = frozenset((SASS_SEPARATOR_COMMA, SASS_SEPARATOR_SPACE))
 
 
-class SassList(collections.namedtuple(
-        'SassList', ('items', 'separator', 'bracketed'),
-)):
+class SassList(collections.namedtuple('SassList', ('items', 'separator'))):
 
-    def __new__(cls, items, separator, bracketed=False):
+    def __new__(cls, items, separator):
         items = tuple(items)
-        assert separator in SEPARATORS, separator
-        assert isinstance(bracketed, bool), bracketed
-        return super(SassList, cls).__new__(cls, items, separator, bracketed)
+        assert separator in SEPARATORS
+        return super(SassList, cls).__new__(cls, items, separator)
 
 
 class SassError(collections.namedtuple('SassError', ('msg',))):

--- a/sasstests.py
+++ b/sasstests.py
@@ -921,12 +921,16 @@ class SassTypesTest(unittest.TestCase):
         assert type(color.a) is float, type(color.a)
 
     def test_sass_list_no_conversion(self):
-        lst = sass.SassList(('foo', 'bar'), sass.SASS_SEPARATOR_COMMA)
+        lst = sass.SassList(
+            ('foo', 'bar'), sass.SASS_SEPARATOR_COMMA,
+        )
         assert type(lst.items) is tuple, type(lst.items)
         assert lst.separator is sass.SASS_SEPARATOR_COMMA, lst.separator
 
     def test_sass_list_conversion(self):
-        lst = sass.SassList(['foo', 'bar'], sass.SASS_SEPARATOR_SPACE)
+        lst = sass.SassList(
+            ['foo', 'bar'], sass.SASS_SEPARATOR_SPACE,
+        )
         assert type(lst.items) is tuple, type(lst.items)
         assert lst.separator is sass.SASS_SEPARATOR_SPACE, lst.separator
 
@@ -1000,12 +1004,6 @@ def returns_space_list():
     return sass.SassList(('medium', 'none'), sass.SASS_SEPARATOR_SPACE)
 
 
-def returns_bracketed_list():
-    return sass.SassList(
-        ('hello', 'ohai'), sass.SASS_SEPARATOR_SPACE, bracketed=True,
-    )
-
-
 def returns_py_dict():
     return {'foo': 'bar'}
 
@@ -1037,7 +1035,6 @@ custom_functions = frozenset([
     sass.SassFunction('returns_color', (), returns_color),
     sass.SassFunction('returns_comma_list', (), returns_comma_list),
     sass.SassFunction('returns_space_list', (), returns_space_list),
-    sass.SassFunction('returns_bracketed_list', (), returns_bracketed_list),
     sass.SassFunction('returns_py_dict', (), returns_py_dict),
     sass.SassFunction('returns_map', (), returns_map),
     sass.SassFunction('identity', ('$x',), identity),
@@ -1057,7 +1054,6 @@ custom_function_map = {
     'returns_color': returns_color,
     'returns_comma_list': returns_comma_list,
     'returns_space_list': returns_space_list,
-    'returns_bracketed_list': returns_bracketed_list,
     'returns_py_dict': returns_py_dict,
     'returns_map': returns_map,
     'identity': identity,
@@ -1077,7 +1073,6 @@ custom_function_set = frozenset([
     returns_color,
     returns_comma_list,
     returns_space_list,
-    returns_bracketed_list,
     returns_py_dict,
     returns_map,
     identity,
@@ -1242,12 +1237,6 @@ class CustomFunctionsTest(unittest.TestCase):
             'a{border-right:medium none}\n',
         )
 
-    def test_bracketed_list(self):
-        self.assertEqual(
-            compile_with_func('a { content: returns_bracketed_list(); }'),
-            'a{content:[hello ohai]}\n'
-        )
-
     def test_py_dict(self):
         self.assertEqual(
             compile_with_func(
@@ -1316,14 +1305,6 @@ class CustomFunctionsTest(unittest.TestCase):
                 'a { border-right: identity(returns_space_list()); }',
             ),
             'a{border-right:medium none}\n',
-        )
-
-    def test_identity_bracketed_list(self):
-        self.assertEqual(
-            compile_with_func(
-                'a { content: identity(returns_bracketed_list()); }',
-            ),
-            'a{content:[hello ohai]}\n',
         )
 
     def test_identity_py_dict(self):


### PR DESCRIPTION
It looks like upstream won't be ready to release these for a while so I'd like to make some more 3.4 releases while they're still pumping those out.

I thought about using a branched workflow but that really just complicates things for a temporary situation.

I *think* the easiest way forward is to temporarily revert these, and then when we're ready to go to 3.5, revert this merge commit and we're there!