### PR TITLE
Sort input files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ for directory in (
         os.path.join('libsass', 'include')
 ):
     for pth, _, filenames in os.walk(directory):
-        for filename in filenames:
+        for filename in sorted(filenames):
             filename = os.path.join(pth, filename)
             if filename.endswith(('.c', '.cpp')):
                 sources.append(filename)


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.