### PR TITLE
Sort input files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ else:
     else:
         link_flags = ['-fPIC', '-lstdc++']
 
+sources.sort()
 sass_extension = Extension(
     '_sass',
     sources,


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.

as an alternative to PR #211