### PR TITLE
include LICENSE file in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include libsass/Makefile
 include .libsass-upstream-version
 include test/*.scss
 include README.rst
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ release = sdist upload build_sphinx upload_doc
 
 [flake8]
 exclude = .tox,build,dist,docs,ez_setup.py,upload_appveyor_builds.py
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
It's best practice to include the LICENSE file in distributions of your code as well as in the repo. The `MANIFEST.in` change makes it go in the .tar.gz files made by `setup.py sdist`, while the `setup.cfg` change is for wheels.