### PR TITLE
System sass

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,38 +148,37 @@ else:
             if platform.system() == 'Darwin':
                 flags.append('-mmacosx-version-min=10.7',)
                 if tuple(
-                map(int, platform.mac_ver()[0].split('.'))
+                        map(int, platform.mac_ver()[0].split('.'))
                 ) >= (10, 9):
                     flags.append(
                         '-Wno-error=unused-command-line-' +
                         'argument-hard-error-in-future',  # noqa
                     )
-            if not system_sass:
-                # Dirty workaround to avoid link error...
-                # Python distutils doesn't provide any way
-                # to configure different flags for each cc and c++.
-                cencode_path = os.path.join(LIBSASS_SOURCE_DIR, 'cencode.c')
-                cencode_body = ''
-                with open(cencode_path) as f:
-                    cencode_body = f.read()
-                with open(cencode_path, 'w') as f:
-                    f.write('''
-                        #ifdef __cplusplus
-                        extern "C" {
-                        #endif
-                    ''')
-                    f.write(cencode_body)
-                    f.write('''
-                        #ifdef __cplusplus
-                        }
-                        #endif
-                    ''')
+            # Dirty workaround to avoid link error...
+            # Python distutils doesn't provide any way
+            # to configure different flags for each cc and c++.
+            cencode_path = os.path.join(LIBSASS_SOURCE_DIR, 'cencode.c')
+            cencode_body = ''
+            with open(cencode_path) as f:
+                cencode_body = f.read()
+            with open(cencode_path, 'w') as f:
+                f.write('''
+                    #ifdef __cplusplus
+                    extern "C" {
+                    #endif
+                ''')
+                f.write(cencode_body)
+                f.write('''
+                    #ifdef __cplusplus
+                    }
+                    #endif
+                ''')
 
-                @atexit.register
-                def restore_cencode():
-                    if os.path.isfile(cencode_path):
-                        with open(cencode_path, 'w') as f:
-                            f.write(cencode_body)
+            @atexit.register
+            def restore_cencode():
+                if os.path.isfile(cencode_path):
+                    with open(cencode_path, 'w') as f:
+                        f.write(cencode_body)
 
         flags = ['-c', '-O3'] + flags
 

--- a/setup.py
+++ b/setup.py
@@ -178,15 +178,15 @@ else:
 
         flags = ['-c', '-O3'] + flags
 
-    if platform.system() == 'FreeBSD':
-        link_flags = ['-fPIC', '-lc++']
-    else:
-        link_flags = ['-fPIC', '-lstdc++']
+        if platform.system() == 'FreeBSD':
+            link_flags = ['-fPIC', '-lc++']
+        else:
+            link_flags = ['-fPIC', '-lstdc++']
 
-libraries = []
-include_dirs = [os.path.join('.', 'libsass', 'include')]
-extra_compile_args = flags + [version_define]
-extra_link_args = link_flags
+    libraries = []
+    include_dirs = [os.path.join('.', 'libsass', 'include')]
+    extra_compile_args = flags + [version_define]
+    extra_link_args = link_flags
 
 sources.sort()
 sass_extension = Extension(

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ if system_sass:
             flags.append('-mmacosx-version-min=10.7',)
             if tuple(map(int, platform.mac_ver()[0].split('.'))) >= (10, 9):
                 flags.append(
-                    '-Wno-error=unused-command-line-argument-hard-error-in-future',  # noqa
+                    '-Wno-error=unused-command-line-'+
+                    'argument-hard-error-in-future',  # noqa
                 )
 
         flags = ['-c', '-O3'] + flags
@@ -126,7 +127,8 @@ else:
         link_flags = []
     else:
         flags = [
-            '-fPIC', '-std=gnu++0x', '-Wall', '-Wno-parentheses', '-Werror=switch',
+            '-fPIC', '-std=gnu++0x', '-Wall',
+            '-Wno-parentheses', '-Werror=switch',
         ]
         platform.mac_ver()
         if platform.system() in ['Darwin', 'FreeBSD']:
@@ -145,14 +147,17 @@ else:
             flags.append('-stdlib=libc++')
             if platform.system() == 'Darwin':
                 flags.append('-mmacosx-version-min=10.7',)
-                if tuple(map(int, platform.mac_ver()[0].split('.'))) >= (10, 9):
+                if tuple(
+                   map(int, platform.mac_ver()[0].split('.'))
+                ) >= (10, 9):
                     flags.append(
-                        '-Wno-error=unused-command-line-argument-hard-error-in-future',  # noqa
+                        '-Wno-error=unused-command-line-'+
+                        'argument-hard-error-in-future',  # noqa
                     )
             if not system_sass:
                 # Dirty workaround to avoid link error...
-                # Python distutils doesn't provide any way to configure different
-                # flags for each cc and c++.
+                # Python distutils doesn't provide any way
+                # to configure different flags for each cc and c++.
                 cencode_path = os.path.join(LIBSASS_SOURCE_DIR, 'cencode.c')
                 cencode_body = ''
                 with open(cencode_path) as f:

--- a/setup.py
+++ b/setup.py
@@ -148,8 +148,8 @@ else:
             if platform.system() == 'Darwin':
                 flags.append('-mmacosx-version-min=10.7',)
                 if tuple(
-                   map(int, platform.mac_ver()[0].split('.'))
-                   ) >= (10, 9):
+                map(int, platform.mac_ver()[0].split('.'))
+                ) >= (10, 9):
                     flags.append(
                         '-Wno-error=unused-command-line-' +
                         'argument-hard-error-in-future',  # noqa

--- a/setup.py
+++ b/setup.py
@@ -162,11 +162,11 @@ sources.sort()
 sass_extension = Extension(
     '_sass',
     sources,
-    include_dirs = include_dirs,
-    depends = headers,
-    extra_compile_args = extra_compile_args,
-    extra_link_args = link_flags,
-    libraries = libraries
+    include_dirs=include_dirs,
+    depends=headers,
+    extra_compile_args=extra_compile_args,
+    extra_link_args=link_flags,
+    libraries=libraries
 )
 
 install_requires = ['six']

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ if system_sass:
         flags.append('-stdlib=libc++')
         if platform.system() == 'Darwin':
             flags.append('-mmacosx-version-min=10.7',)
-            if tuple(map(int, platform.mac_ver()[0].split('.'))) >= (10, 9):
+            macver = tuple(map(int, platform.mac_ver()[0].split('.')))
+            if macver >= (10, 9):
                 flags.append(
                     '-Wno-error=unused-command-line-' +
                     'argument-hard-error-in-future',  # noqa
@@ -147,9 +148,8 @@ else:
             flags.append('-stdlib=libc++')
             if platform.system() == 'Darwin':
                 flags.append('-mmacosx-version-min=10.7',)
-                if tuple(
-                        map(int, platform.mac_ver()[0].split('.'))
-                ) >= (10, 9):
+                macver = tuple(map(int, platform.mac_ver()[0].split('.')))
+                if macver >= (10, 9):
                     flags.append(
                         '-Wno-error=unused-command-line-' +
                         'argument-hard-error-in-future',  # noqa

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import tempfile
 
 from setuptools import Extension, setup
 
-system_sass = bool(os.environ["SYSTEMSASS"], False)
+system_sass = os.environ.get('SYSTEMSASS', False)
 
 sources = ['pysass.cpp']
 headers = []

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if system_sass:
             flags.append('-mmacosx-version-min=10.7',)
             if tuple(map(int, platform.mac_ver()[0].split('.'))) >= (10, 9):
                 flags.append(
-                    '-Wno-error=unused-command-line-'+
+                    '-Wno-error=unused-command-line-' +
                     'argument-hard-error-in-future',  # noqa
                 )
 
@@ -149,9 +149,9 @@ else:
                 flags.append('-mmacosx-version-min=10.7',)
                 if tuple(
                    map(int, platform.mac_ver()[0].split('.'))
-                ) >= (10, 9):
+                   ) >= (10, 9):
                     flags.append(
-                        '-Wno-error=unused-command-line-'+
+                        '-Wno-error=unused-command-line-' +
                         'argument-hard-error-in-future',  # noqa
                     )
             if not system_sass:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ system_sass = os.environ.get('SYSTEMSASS', False)
 
 sources = ['pysass.cpp']
 headers = []
-version_define=''
+version_define = ''
 
 if not system_sass:
     LIBSASS_SOURCE_DIR = os.path.join('libsass', 'src')
@@ -32,7 +32,6 @@ if not system_sass:
         print('  git submodule update --init', file=sys.stderr)
         print(file=sys.stderr)
         exit(1)
-
 
     # Determine the libsass version from the git checkout
     if os.path.exists(os.path.join('libsass', '.git')):
@@ -53,7 +52,8 @@ if not system_sass:
         libsass_version = libsass_version_file.read().decode('UTF-8').strip()
         if sys.platform == 'win32':
             # This looks wrong, but is required for some reason :(
-            version_define = r'/DLIBSASS_VERSION="\"{0}\""'.format(libsass_version)
+            version_define = r'/DLIBSASS_VERSION="\"{0}\""'.format(
+                                                            libsass_version)
         else:
             version_define = '-DLIBSASS_VERSION="{0}"'.format(libsass_version)
 

--- a/setup.py
+++ b/setup.py
@@ -184,10 +184,12 @@ else:
             link_flags = ['-fPIC', '-lstdc++']
         libraries = []
         include_dirs = [os.path.join('.', 'libsass', 'include')]
+        print('Assigned include_dirs = %s' % (include_dirs))
         extra_compile_args = flags + [version_define]
         extra_link_args = link_flags
 
 sources.sort()
+print('Include_dirs = %s' % (include_dirs))
 sass_extension = Extension(
     '_sass',
     sources,

--- a/setup.py
+++ b/setup.py
@@ -178,18 +178,17 @@ else:
 
         flags = ['-c', '-O3'] + flags
 
-        if platform.system() == 'FreeBSD':
-            link_flags = ['-fPIC', '-lc++']
-        else:
-            link_flags = ['-fPIC', '-lstdc++']
-        libraries = []
-        include_dirs = [os.path.join('.', 'libsass', 'include')]
-        print('Assigned include_dirs = %s' % (include_dirs))
-        extra_compile_args = flags + [version_define]
-        extra_link_args = link_flags
+    if platform.system() == 'FreeBSD':
+        link_flags = ['-fPIC', '-lc++']
+    else:
+        link_flags = ['-fPIC', '-lstdc++']
+
+libraries = []
+include_dirs = [os.path.join('.', 'libsass', 'include')]
+extra_compile_args = flags + [version_define]
+extra_link_args = link_flags
 
 sources.sort()
-print('Include_dirs = %s' % (include_dirs))
 sass_extension = Extension(
     '_sass',
     sources,

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,7 @@ import tempfile
 
 from setuptools import Extension, setup
 
-try:
-    system_sass = bool(os.environ["SYSTEMSASS"])
-except KeyError:
-    system_sass = False
+system_sass = bool(os.environ["SYSTEMSASS"], False)
 
 sources = ['pysass.cpp']
 headers = []
@@ -152,25 +149,24 @@ else:
 
 if system_sass:
     libraries = ['sass']
-    include_dirs=[]
-    extra_compile_args=flags
-    extra_link_args=link_flags
+    include_dirs = []
+    extra_compile_args = flags
+    extra_link_args = link_flags
 else:
     libraries = []
-    include_dirs=[os.path.join('.', 'libsass', 'include')]
-    extra_compile_args=flags + [version_define]
-    extra_link_args=link_flags
-    libraries=libraries
+    include_dirs = [os.path.join('.', 'libsass', 'include')]
+    extra_compile_args = flags + [version_define]
+    extra_link_args = link_flags
 
 sources.sort()
 sass_extension = Extension(
     '_sass',
     sources,
-    include_dirs=include_dirs,
-    depends=headers,
-    extra_compile_args=extra_compile_args,
-    extra_link_args=link_flags,
-    libraries=libraries
+    include_dirs = include_dirs,
+    depends = headers,
+    extra_compile_args = extra_compile_args,
+    extra_link_args = link_flags,
+    libraries = libraries
 )
 
 install_requires = ['six']


### PR DESCRIPTION
This PR implements solution for using system-installed libsass library to build the python sass extension.
This will help to get rid of some hacks/downstream-patches in Fedora and other distributions' packaging.