### PR TITLE
doc: support sphinx 6.0 ext.extlinks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,11 +267,11 @@ intersphinx_mapping = {
 
 
 extlinks = {
-    'issue': ('https://github.com/sass/libsass-python/issues/%s', '#'),
+    'issue': ('https://github.com/sass/libsass-python/issues/%s', '#%s'),
     'branch': (
         'https://github.com/sass/libsass-python/compare/main...%s',
-        '',
+        '%s',
     ),
-    'commit': ('https://github.com/sass/libsass-python/commit/%s', ''),
-    'upcommit': ('https://github.com/sass/libsass/commit/%s', ''),
+    'commit': ('https://github.com/sass/libsass-python/commit/%s', '%s'),
+    'upcommit': ('https://github.com/sass/libsass/commit/%s', '%s'),
 }


### PR DESCRIPTION
As sphinx 5 already warns, sphinx.ext.extlinks requires a caption string to contain (exactly) one '%s' if caption is not None, and now sphinx forces this with the following change:

https://github.com/sphinx-doc/sphinx/pull/10471

Fixes #424 .